### PR TITLE
Typo in is_sync_byte comment

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -518,7 +518,7 @@ impl<'buf> Packet<'buf> {
     /// The fixed 188 byte size of a transport stream packet.
     pub const SIZE: usize = 188;
 
-    /// returns `true` if the given value is a valid synchronisation byte, the value `0x42`, which
+    /// returns `true` if the given value is a valid synchronisation byte, the value `Packet::SYNC_BYTE` (0x47), which
     /// must appear at the start of every transport stream packet.
     #[inline(always)]
     pub fn is_sync_byte(b: u8) -> bool {


### PR DESCRIPTION
The is_sync_byte function incorrectly states that the value of the transport stream sync byte is 0x42, maybe a Hitchhiker's Guide to the Galaxy reference? Updated comment to correct value of 0x47 with reference to Packet::SYNC_BYTE