### PR TITLE
Update descriptor_enum to work with the current edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 categories = [ "multimedia::video", "parser-implementations" ]
 keywords = [ "mpegts", "ISO-13818-1", "H-222-0" ]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 fixedbitset = "0.4.0"

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -106,7 +106,7 @@ macro_rules! descriptor_enum {
         $name:ident {
             $(
                 $(#[$inner:ident $($args:tt)*])*
-                $case_name:ident $($tags:pat)|* => $t:ident
+                $case_name:ident $($tags:pat_param)|* => $t:ident
             ),*,
         }
     ) => {


### PR DESCRIPTION
This way 2021 can be used.