### PR TITLE
Add clippy job and other improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
   - dependency-name: hex-literal
     versions:
     - ">= 0.3.a, < 0.4"
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,35 +9,55 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@1.62.0
+
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --all-targets
+
     - name: Run tests
       run: cargo test --verbose
 
+
   coverage:
-    name: Rust code coverage
-    runs-on: ubuntu-latest
+    name: Coverage
+    runs-on: ubuntu-22.04
+    container:
+      image: xd009642/tarpaulin:0.22.0-slim
+      options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: '--exclude-files shootout --exclude-files benches --exclude-files fuzz --out Lcov -- --test-threads 1'
+      - name: Generate code coverage
+        run: |
+          cargo tarpaulin --verbose --timeout 120 --exclude-files shootout --exclude-files benches --exclude-files fuzz --out Lcov -- --test-threads 1
 
       - name: upload to Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: './lcov.info'
+
+
+  clippy:
+    name: Lint 📎
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@1.62.0
+        with:
+          components: clippy
+
+      - name: Run clippy
+        # TODO: Use a tag once available
+        uses: actions-rs-plus/clippy-check@43303e5bdba1efbf5961020e5743d530fb1de0c1
+        with:
+          args: --all-features


### PR DESCRIPTION
 - dependabot for github-actions
 - pin runs-on version rather than latest
 - build --all-targets (checks examples too)
 - checkout v2 -> v3
 - actions-rs/toolchain -> dtolnay/rust-toolchain (maintained)
 - pin toolchain version rather than latest stable