### PR TITLE
Use tagged release for clippy action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,6 @@ jobs:
           components: clippy
 
       - name: Run clippy
-        # TODO: Use a tag once available
-        uses: actions-rs-plus/clippy-check@017a9863761ab793c6ed7b7ce9adb38cdf67694c
+        uses: actions-rs-plus/clippy-check@v2.0.0
         with:
           args: --all-features


### PR DESCRIPTION
No need to use a commit-id any more it seems