### PR TITLE
Convert StreamType and StreamId types to structs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ pub mod mpegts_crc;
 pub mod pes;
 pub mod psi;
 
+use std::fmt;
+use std::fmt::Formatter;
 // expose access to FormatIdentifier, which is part of the public API of
 // descriptor::registration::RegistrationDescriptor
 pub use smptera_format_identifiers_rust as smptera;
@@ -50,175 +52,184 @@ pub use smptera_format_identifiers_rust as smptera;
 ///
 /// As returned by
 /// [`StreamInfo::stream_type()`](psi/pmt/struct.StreamInfo.html#method.stream_type).
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub enum StreamType {
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+pub struct StreamType(u8);
+
+impl StreamType {
     // 0x00 reserved
     /// ISO/IEC 11172 Video
-    Iso11172Video,
+    pub const ISO_11172_VIDEO: StreamType = StreamType(0x01);
     /// ITU-T Rec. H.262 | ISO/IEC 13818-2 Video or ISO/IEC 11172-2 constrained parameter video stream
-    H262,
+    pub const H262: StreamType = StreamType(0x02);
     /// ISO/IEC 11172 Audio
-    Iso11172Audio,
+    pub const ISO_11172_AUDIO: StreamType = StreamType(0x03);
     /// ISO/IEC 13818-3 Audio
-    Iso138183Audio,
+    pub const ISO_138183_AUDIO: StreamType = StreamType(0x04);
     /// ITU-T Rec. H.222.0 | ISO/IEC 13818-1 private_sections
-    H2220PrivateSections,
+    pub const H222_0_PRIVATE_SECTIONS: StreamType = StreamType(0x05);
     /// ITU-T Rec. H.222.0 | ISO/IEC 13818-1 PES packets containing private data
-    H2220PesPrivateData,
+    pub const H222_0_PES_PRIVATE_DATA: StreamType = StreamType(0x06);
     /// ISO/IEC 13522 MHEG
-    Mheg,
+    pub const MHEG: StreamType = StreamType(0x07);
     /// ITU-T Rec. H.222.0 | ISO/IEC 13818-1 Annex A DSM-CC
-    H2220DsmCc,
+    pub const H222_0_DSM_CC: StreamType = StreamType(0x08);
     /// ITU-T Rec. H.222.1
-    H2221,
+    pub const H2221: StreamType = StreamType(0x09);
     /// ISO/IEC 13818-6 DSM CC multiprotocol encapsulation
-    Iso138186MultiprotocolEncapsulation,
+    pub const ISO_13818_6_MULTIPROTOCOL_ENCAPSULATION: StreamType = StreamType(0x0A);
     /// ISO/IEC 13818-6 DSM CC U-N messages
-    DsmccUnMessages,
+    pub const DSMCC_UN_MESSAGES: StreamType = StreamType(0x0B);
     /// ISO/IEC 13818-6 DSM CC stream descriptors
-    DsmccStreamDescriptors,
+    pub const DSMCC_STREAM_DESCRIPTORS: StreamType = StreamType(0x0C);
     /// ISO/IEC 13818-6 DSM CC tabled data
-    DsmccSections,
+    pub const DSMCC_SECTIONS: StreamType = StreamType(0x0D);
     /// ITU-T Rec. H.222.0 | ISO/IEC 13818-1 auxiliary
-    H2220Auxiliary,
+    pub const H222_0_AUXILIARY: StreamType = StreamType(0x0E);
     /// ISO/IEC 13818-7 Audio with ADTS transport syntax
-    Adts,
+    pub const ADTS: StreamType = StreamType(0x0F);
     /// ISO/IEC 14496-2 Visual
-    Iso144962Visual,
+    pub const ISO_14496_2_VISUAL: StreamType = StreamType(0x10);
     /// ISO/IEC 14496-3 Audio with the LATM transport syntax as defined in ISO/IEC 14496-3 / AMD 1
-    Latm,
+    pub const LATM: StreamType = StreamType(0x11);
     /// ISO/IEC 14496-1 SL-packetized stream or FlexMux stream carried in PES packets
-    FlexMuxPes,
+    pub const FLEX_MUX_PES: StreamType = StreamType(0x12);
     /// ISO/IEC 14496-1 SL-packetized stream or FlexMux stream carried in ISO/IEC14496_sections.
-    FlexMuxIso14496Sections,
+    pub const FLEX_MUX_ISO_14496_SECTIONS: StreamType = StreamType(0x13);
     /// ISO/IEC 13818-6 Synchronized Download Protocol
-    SynchronizedDownloadProtocol,
+    pub const SYNCHRONIZED_DOWNLOAD_PROTOCOL: StreamType = StreamType(0x14);
     /// Metadata carried in PES packets
-    MetadataInPes,
+    pub const METADATA_IN_PES: StreamType = StreamType(0x15);
     /// Metadata carried in metadata_sections
-    MetadataInMetadataSections,
+    pub const METADATA_IN_METADATA_SECTIONS: StreamType = StreamType(0x16);
     /// Metadata carried in ISO/IEC 13818-6 Data Carousel
-    DsmccDataCarouselMetadata,
+    pub const DSMCC_DATA_CAROUSEL_METADATA: StreamType = StreamType(0x17);
     /// Metadata carried in ISO/IEC 13818-6 Object Carousel
-    DsmccObjectCarouselMetadata,
+    pub const DSMCC_OBJECT_CAROUSEL_METADATA: StreamType = StreamType(0x18);
     /// Metadata carried in ISO/IEC 13818-6 Synchronized Download Protocol
-    SynchronizedDownloadProtocolMetadata,
+    pub const SYNCHRONIZED_DOWNLOAD_PROTOCOL_METADATA: StreamType = StreamType(0x19);
     /// IPMP stream (defined in ISO/IEC 13818-11, MPEG-2 IPMP)
-    Ipmp,
+    pub const IPMP: StreamType = StreamType(0x1a);
     /// AVC video stream as defined in ITU-T Rec. H.264 | ISO/IEC 14496-10 Video
-    H264,
+    pub const H264: StreamType = StreamType(0x1b);
     /// ISO/IEC 14496-3 Audio, without using any additional transport syntax, such as DST, ALS and SLS
-    AudioWithoutTransportSyntax,
+    pub const AUDIO_WITHOUT_TRANSPORT_SYNTAX: StreamType = StreamType(0x1c);
     /// ISO/IEC 14496-17 Text
-    Iso1449617text,
+    pub const ISO_14496_17_TEXT: StreamType = StreamType(0x1d);
     // 0x1e-0x23 reserved
     /// ITU-T Rec. H.265 and ISO/IEC 23008-2
-    H265,
+    pub const H265: StreamType = StreamType(0x24);
     // 0x26-0x41 reserved
     /// Chinese Video Standard
-    ChineseVideoStandard,
+    pub const CHINESE_VIDEO_STANDARD: StreamType = StreamType(0x42);
     // 0x43-0x7f reserved
     // 0x80 privately defined
     /// Dolby Digital (AC-3) audio for ATSC
-    AtscDolbyDigitalAudio,
+    pub const ATSC_DOLBY_DIGITAL_AUDIO: StreamType = StreamType(0x81);
     // 0x82-0x94 privately defined
     /// ATSC Data Service Table, Network Resources Table
-    AtscDsmccNetworkResourcesTable,
+    pub const ATSC_DSMCC_NETWORK_RESOURCES_TABLE: StreamType = StreamType(0x95);
     // 0x95-0xc1 privately defined
     /// PES packets containing ATSC streaming synchronous data
-    AtscDsmccSynchronousData,
-    /// 0xc3-0xff privately defined,
-    Private(u8),
-    /// Reserved for use in future standards
-    Reserved(u8),
-}
-impl StreamType {
+    pub const ATSC_DSMCC_SYNCHRONOUS_DATA: StreamType = StreamType(0xc2);
+    // 0xc3-0xff privately defined,
+
     /// `true` if packets of a stream with this `stream_type` will carry data in Packetized
     /// Elementary Stream format.
     pub fn is_pes(self) -> bool {
-        match self {
-            StreamType::Iso11172Video
-            | StreamType::H262
-            | StreamType::Iso11172Audio
-            | StreamType::Iso138183Audio
-            | StreamType::H2220PesPrivateData
-            | StreamType::Mheg
-            | StreamType::H2220DsmCc
-            | StreamType::H2221
-            | StreamType::Iso138186MultiprotocolEncapsulation
-            | StreamType::DsmccUnMessages
-            | StreamType::DsmccStreamDescriptors
-            | StreamType::DsmccSections
-            | StreamType::H2220Auxiliary
-            | StreamType::Adts
-            | StreamType::Iso144962Visual
-            | StreamType::Latm
-            | StreamType::FlexMuxPes
-            | StreamType::FlexMuxIso14496Sections
-            | StreamType::SynchronizedDownloadProtocol
-            | StreamType::MetadataInPes
-            | StreamType::MetadataInMetadataSections
-            | StreamType::DsmccDataCarouselMetadata
-            | StreamType::DsmccObjectCarouselMetadata
-            | StreamType::SynchronizedDownloadProtocolMetadata
-            | StreamType::Ipmp
-            | StreamType::H264
-            | StreamType::AudioWithoutTransportSyntax
-            | StreamType::Iso1449617text
-            | StreamType::H265
-            | StreamType::ChineseVideoStandard
-            | StreamType::AtscDolbyDigitalAudio
-            | StreamType::AtscDsmccNetworkResourcesTable
-            | StreamType::AtscDsmccSynchronousData => true,
-
-            StreamType::H2220PrivateSections | StreamType::Reserved(_) | StreamType::Private(_) => {
-                false
-            }
-        }
+        matches!(
+            self,
+            StreamType::ISO_11172_VIDEO
+                | StreamType::H262
+                | StreamType::ISO_11172_AUDIO
+                | StreamType::ISO_138183_AUDIO
+                | StreamType::H222_0_PES_PRIVATE_DATA
+                | StreamType::MHEG
+                | StreamType::H222_0_DSM_CC
+                | StreamType::H2221
+                | StreamType::ISO_13818_6_MULTIPROTOCOL_ENCAPSULATION
+                | StreamType::DSMCC_UN_MESSAGES
+                | StreamType::DSMCC_STREAM_DESCRIPTORS
+                | StreamType::DSMCC_SECTIONS
+                | StreamType::H222_0_AUXILIARY
+                | StreamType::ADTS
+                | StreamType::ISO_14496_2_VISUAL
+                | StreamType::LATM
+                | StreamType::FLEX_MUX_PES
+                | StreamType::FLEX_MUX_ISO_14496_SECTIONS
+                | StreamType::SYNCHRONIZED_DOWNLOAD_PROTOCOL
+                | StreamType::METADATA_IN_PES
+                | StreamType::METADATA_IN_METADATA_SECTIONS
+                | StreamType::DSMCC_DATA_CAROUSEL_METADATA
+                | StreamType::DSMCC_OBJECT_CAROUSEL_METADATA
+                | StreamType::SYNCHRONIZED_DOWNLOAD_PROTOCOL_METADATA
+                | StreamType::IPMP
+                | StreamType::H264
+                | StreamType::AUDIO_WITHOUT_TRANSPORT_SYNTAX
+                | StreamType::ISO_14496_17_TEXT
+                | StreamType::H265
+                | StreamType::CHINESE_VIDEO_STANDARD
+                | StreamType::ATSC_DOLBY_DIGITAL_AUDIO
+                | StreamType::ATSC_DSMCC_NETWORK_RESOURCES_TABLE
+                | StreamType::ATSC_DSMCC_SYNCHRONOUS_DATA
+        )
     }
 }
-impl From<u8> for StreamType {
-    fn from(val: u8) -> Self {
-        match val {
-            0x01 => StreamType::Iso11172Video,
-            0x02 => StreamType::H262,
-            0x03 => StreamType::Iso11172Audio,
-            0x04 => StreamType::Iso138183Audio,
-            0x05 => StreamType::H2220PrivateSections,
-            0x06 => StreamType::H2220PesPrivateData,
-            0x07 => StreamType::Mheg,
-            0x08 => StreamType::H2220DsmCc,
-            0x09 => StreamType::H2221,
-            0x0A => StreamType::Iso138186MultiprotocolEncapsulation,
-            0x0B => StreamType::DsmccUnMessages,
-            0x0C => StreamType::DsmccStreamDescriptors,
-            0x0D => StreamType::DsmccSections,
-            0x0E => StreamType::H2220Auxiliary,
-            0x0F => StreamType::Adts,
-            0x10 => StreamType::Iso144962Visual,
-            0x11 => StreamType::Latm,
-            0x12 => StreamType::FlexMuxPes,
-            0x13 => StreamType::FlexMuxIso14496Sections,
-            0x14 => StreamType::SynchronizedDownloadProtocol,
-            0x15 => StreamType::MetadataInPes,
-            0x16 => StreamType::MetadataInMetadataSections,
-            0x17 => StreamType::DsmccDataCarouselMetadata,
-            0x18 => StreamType::DsmccObjectCarouselMetadata,
-            0x19 => StreamType::SynchronizedDownloadProtocolMetadata,
-            0x1a => StreamType::Ipmp,
-            0x1b => StreamType::H264,
-            0x1c => StreamType::AudioWithoutTransportSyntax,
-            0x1d => StreamType::Iso1449617text,
-            0x24 => StreamType::H265,
-            0x42 => StreamType::ChineseVideoStandard,
-            0x81 => StreamType::AtscDolbyDigitalAudio,
-            0x95 => StreamType::AtscDsmccNetworkResourcesTable,
-            0xc2 => StreamType::AtscDsmccSynchronousData,
+impl fmt::Debug for StreamType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            StreamType::ISO_11172_VIDEO => f.write_str("ISO_11172_VIDEO"),
+            StreamType::H262 => f.write_str("H262"),
+            StreamType::ISO_11172_AUDIO => f.write_str("ISO_11172_AUDIO"),
+            StreamType::ISO_138183_AUDIO => f.write_str("ISO_138183_AUDIO"),
+            StreamType::H222_0_PRIVATE_SECTIONS => f.write_str("H222_0_PRIVATE_SECTIONS"),
+            StreamType::H222_0_PES_PRIVATE_DATA => f.write_str("H222_0_PES_PRIVATE_DATA"),
+            StreamType::MHEG => f.write_str("MHEG"),
+            StreamType::H222_0_DSM_CC => f.write_str("H222_0_DSM_CC"),
+            StreamType::H2221 => f.write_str("H2221"),
+            StreamType::ISO_13818_6_MULTIPROTOCOL_ENCAPSULATION => {
+                f.write_str("ISO_13818_6_MULTIPROTOCOL_ENCAPSULATION")
+            }
+            StreamType::DSMCC_UN_MESSAGES => f.write_str("DSMCC_UN_MESSAGES"),
+            StreamType::DSMCC_STREAM_DESCRIPTORS => f.write_str("DSMCC_STREAM_DESCRIPTORS"),
+            StreamType::DSMCC_SECTIONS => f.write_str("DSMCC_SECTIONS"),
+            StreamType::H222_0_AUXILIARY => f.write_str("H222_0_AUXILIARY"),
+            StreamType::ADTS => f.write_str("ADTS"),
+            StreamType::ISO_14496_2_VISUAL => f.write_str("ISO_14496_2_VISUAL"),
+            StreamType::LATM => f.write_str("LATM"),
+            StreamType::FLEX_MUX_PES => f.write_str("FLEX_MUX_PES"),
+            StreamType::FLEX_MUX_ISO_14496_SECTIONS => f.write_str("FLEX_MUX_ISO_14496_SECTIONS"),
+            StreamType::SYNCHRONIZED_DOWNLOAD_PROTOCOL => {
+                f.write_str("SYNCHRONIZED_DOWNLOAD_PROTOCOL")
+            }
+            StreamType::METADATA_IN_PES => f.write_str("METADATA_IN_PES"),
+            StreamType::METADATA_IN_METADATA_SECTIONS => {
+                f.write_str("METADATA_IN_METADATA_SECTIONS")
+            }
+            StreamType::DSMCC_DATA_CAROUSEL_METADATA => f.write_str("DSMCC_DATA_CAROUSEL_METADATA"),
+            StreamType::DSMCC_OBJECT_CAROUSEL_METADATA => {
+                f.write_str("DSMCC_OBJECT_CAROUSEL_METADATA")
+            }
+            StreamType::SYNCHRONIZED_DOWNLOAD_PROTOCOL_METADATA => {
+                f.write_str("SYNCHRONIZED_DOWNLOAD_PROTOCOL_METADATA")
+            }
+            StreamType::IPMP => f.write_str("IPMP"),
+            StreamType::H264 => f.write_str("H264"),
+            StreamType::AUDIO_WITHOUT_TRANSPORT_SYNTAX => {
+                f.write_str("AUDIO_WITHOUT_TRANSPORT_SYNTAX")
+            }
+            StreamType::ISO_14496_17_TEXT => f.write_str("ISO_14496_17_TEXT"),
+            StreamType::H265 => f.write_str("H265"),
+            StreamType::CHINESE_VIDEO_STANDARD => f.write_str("CHINESE_VIDEO_STANDARD"),
+            StreamType::ATSC_DOLBY_DIGITAL_AUDIO => f.write_str("ATSC_DOLBY_DIGITAL_AUDIO"),
+            StreamType::ATSC_DSMCC_NETWORK_RESOURCES_TABLE => {
+                f.write_str("ATSC_DSMCC_NETWORK_RESOURCES_TABLE")
+            }
+            StreamType::ATSC_DSMCC_SYNCHRONOUS_DATA => f.write_str("ATSC_DSMCC_SYNCHRONOUS_DATA"),
             _ => {
-                if val >= 0x80 {
-                    StreamType::Private(val)
+                if self.0 >= 0x80 {
+                    f.write_fmt(format_args!("PRIVATE({})", self.0))
                 } else {
-                    StreamType::Reserved(val)
+                    f.write_fmt(format_args!("RESERVED({})", self.0))
                 }
             }
         }
@@ -227,44 +238,7 @@ impl From<u8> for StreamType {
 
 impl From<StreamType> for u8 {
     fn from(val: StreamType) -> Self {
-        match val {
-            StreamType::Iso11172Video => 0x01,
-            StreamType::H262 => 0x02,
-            StreamType::Iso11172Audio => 0x03,
-            StreamType::Iso138183Audio => 0x04,
-            StreamType::H2220PrivateSections => 0x05,
-            StreamType::H2220PesPrivateData => 0x06,
-            StreamType::Mheg => 0x07,
-            StreamType::H2220DsmCc => 0x08,
-            StreamType::H2221 => 0x09,
-            StreamType::Iso138186MultiprotocolEncapsulation => 0x0A,
-            StreamType::DsmccUnMessages => 0x0B,
-            StreamType::DsmccStreamDescriptors => 0x0C,
-            StreamType::DsmccSections => 0x0D,
-            StreamType::H2220Auxiliary => 0x0E,
-            StreamType::Adts => 0x0F,
-            StreamType::Iso144962Visual => 0x10,
-            StreamType::Latm => 0x11,
-            StreamType::FlexMuxPes => 0x12,
-            StreamType::FlexMuxIso14496Sections => 0x13,
-            StreamType::SynchronizedDownloadProtocol => 0x14,
-            StreamType::MetadataInPes => 0x15,
-            StreamType::MetadataInMetadataSections => 0x16,
-            StreamType::DsmccDataCarouselMetadata => 0x17,
-            StreamType::DsmccObjectCarouselMetadata => 0x18,
-            StreamType::SynchronizedDownloadProtocolMetadata => 0x19,
-            StreamType::Ipmp => 0x1a,
-            StreamType::H264 => 0x1b,
-            StreamType::AudioWithoutTransportSyntax => 0x1c,
-            StreamType::Iso1449617text => 0x1d,
-            StreamType::H265 => 0x24,
-            StreamType::ChineseVideoStandard => 0x42,
-            StreamType::AtscDolbyDigitalAudio => 0x81,
-            StreamType::AtscDsmccNetworkResourcesTable => 0x95,
-            StreamType::AtscDsmccSynchronousData => 0xc2,
-            StreamType::Reserved(val) => val,
-            StreamType::Private(val) => val,
-        }
+        val.0
     }
 }
 
@@ -275,23 +249,31 @@ pub const STUFFING_PID: packet::Pid = packet::Pid::new(0x1fff);
 mod test {
     use super::StreamType;
 
-    #[test]
-    fn mappings() {
-        for st in 0..=255 {
-            assert_eq!(st, StreamType::from(st).into())
+    fn is_reserved(st: &StreamType) -> bool {
+        match st.0 {
+            0x00 | 0x1e..=0x23 | 0x25..=0x41 | 0x43..=0x7f => true,
+            _ => false,
+        }
+    }
+
+    fn is_private(st: &StreamType) -> bool {
+        match st.0 {
+            // TODO: 0x95 now public, or is ATSC_DSMCC_NETWORK_RESOURCES_TABLE incorrect?
+            0x80 | 0x82..=0x94 | 0x96..=0xc1 | 0xc3..=0xff => true,
+            _ => false,
         }
     }
 
     #[test]
     fn pes() {
         for st in 0..=255 {
-            let ty = StreamType::from(st);
-            match ty {
-                StreamType::H2220PrivateSections
-                | StreamType::Reserved(_)
-                | StreamType::Private(_) => assert!(!ty.is_pes(), "{:?}", ty),
-                _ => assert!(ty.is_pes(), "{:?}", ty),
+            let ty = StreamType(st);
+            if ty == StreamType::H222_0_PRIVATE_SECTIONS || is_reserved(&ty) || is_private(&ty) {
+                assert!(!ty.is_pes(), "{:?}", ty);
+            } else {
+                assert!(ty.is_pes(), "{:?}", ty);
             }
+            let _ = format!("{:?}", ty);
         }
     }
 }

--- a/src/psi/pmt.rs
+++ b/src/psi/pmt.rs
@@ -164,7 +164,7 @@ impl<'buf> StreamInfo<'buf> {
 
     /// The type of this stream
     pub fn stream_type(&self) -> StreamType {
-        self.data[0].into()
+        StreamType(self.data[0])
     }
     /// The Pid that will be used for TS packets containing the data of this stream
     pub fn elementary_pid(&self) -> packet::Pid {


### PR DESCRIPTION
The use of enums for these types presented a problem for backwards compatibility.  If code was witten to make use of the Reserved(u8) or Unknown(u8) variants, and then in future we add an explicit variant to the enum of that partucular value becomes defined by the spec, then code expecting to expect that value to be available in e.g. Reserved will silently break - it will not hit a compilation error, but it will not do the expected thing any more at runtime.  By converting these types to simply u8 wrappers calling code can just construct their own instances for values not currently defined in the spec, and those values will be compatibe with any definitions that this crate adds in future.

Benchmarking shows a very slight performance improvement with this change (sub 1%).