### PR TITLE
SCTE35 0x86 stream type constant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,8 @@ impl StreamType {
     // 0x80 privately defined
     /// Dolby Digital (AC-3) audio for ATSC
     pub const ATSC_DOLBY_DIGITAL_AUDIO: StreamType = StreamType(0x81);
-    // 0x86 SCTE-35 digital program insertion cue message
+    // 0x86 scte35
+    /// SCTE-35 digital program insertion cue message
     pub const SCTE35: StreamType = StreamType(0x86);
     // 0x82-0x94 privately defined
     /// ATSC Data Service Table, Network Resources Table

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,8 @@ impl StreamType {
     // 0x80 privately defined
     /// Dolby Digital (AC-3) audio for ATSC
     pub const ATSC_DOLBY_DIGITAL_AUDIO: StreamType = StreamType(0x81);
+    // 0x86 SCTE-35 digital program insertion cue message
+    pub const SCTE35: StreamType = StreamType(0x86);
     // 0x82-0x94 privately defined
     /// ATSC Data Service Table, Network Resources Table
     pub const ATSC_DSMCC_NETWORK_RESOURCES_TABLE: StreamType = StreamType(0x95);


### PR DESCRIPTION
Hello there!

Just started working with rust and found this brilliant repo.
I'm working on ad tech project for ad insertion and we are using SCTE35 standard for ad block boundaries

More information about SCTE35 in mpegts
https://en.wikipedia.org/wiki/Program-specific_information